### PR TITLE
States can be integers, booleans, or strings

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
-install:
+help: ## help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+install: ## install development requirements
 	pip install -r requirements_dev.txt
 
-test:
+test: ## run tests
 	pytest
 
-test-cov:
+test-cov: ## run tests with coverage
 	pytest --cov finite_state_machine/ --cov examples/
 
-test-covhtml:
+test-covhtml: ## run tests with coverage; view in browser
 	pytest --cov finite_state_machine/ --cov examples/ --cov-report html && open ./htmlcov/index.html

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ class Turnstile(StateMachine):
 
     def __init__(self):
         self.state = self.initial_state
+        super().__init__()
 
     @transition(source=["close", "open"], target="open")
     def insert_coin(self):

--- a/examples/boolean_field.py
+++ b/examples/boolean_field.py
@@ -1,0 +1,24 @@
+from finite_state_machine import StateMachine, transition
+
+
+def account_in_good_standing(self):
+    return len(self.account.bills_outstanding) == 0
+
+
+class EnableFeatureStateMachine(StateMachine):
+    """Example state machine around a feature flag field"""
+
+    def __init__(self, account):
+        self.account = account
+        self.state = account.feature["enabled"]
+        super().__init__()
+
+    @transition(
+        source=[True, False], target=True, conditions=[account_in_good_standing]
+    )
+    def enable_feature(self):
+        pass
+
+    @transition(source=True, target=False)
+    def disable_feature(self):
+        pass

--- a/examples/boolean_field.py
+++ b/examples/boolean_field.py
@@ -13,9 +13,7 @@ class EnableFeatureStateMachine(StateMachine):
         self.state = account.feature["enabled"]
         super().__init__()
 
-    @transition(
-        source=[True, False], target=True, conditions=[account_in_good_standing]
-    )
+    @transition(source=False, target=True, conditions=[account_in_good_standing])
     def enable_feature(self):
         pass
 

--- a/examples/turnstile.py
+++ b/examples/turnstile.py
@@ -6,6 +6,7 @@ class Turnstile(StateMachine):
 
     def __init__(self):
         self.state = self.initial_state
+        super().__init__()
 
     @transition(source=["close", "open"], target="open")
     def insert_coin(self):

--- a/finite_state_machine/state_machine.py
+++ b/finite_state_machine/state_machine.py
@@ -11,12 +11,16 @@ class StateMachine:
 
 
 def transition(source, target, conditions=None):
-    if isinstance(source, str):
+    allowed_types = [str, bool, int]
+
+    if type(source) in allowed_types:
         source = [source]
     if not isinstance(source, list):
-        raise ValueError("Source can be a string or list")
-    if not isinstance(target, str):
-        raise ValueError("Target needs to be a string")
+        raise ValueError("Source can be a bool, int, string or list")
+
+    if type(target) not in allowed_types:
+        raise ValueError("Target needs to be a bool, int or string")
+
     if not conditions:
         conditions = []
     if not isinstance(conditions, list):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,9 @@ classifiers = [
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.3",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-requires-python = ">2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, >=3.3, <4"
+requires-python = "!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, >=3.3, <4"
 keywords="finite-state-machine finite-automata state-machine"
 license="MIT"
 

--- a/tests/examples/test_boolean_field.py
+++ b/tests/examples/test_boolean_field.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+import pytest
+
+from examples.boolean_field import EnableFeatureStateMachine
+
+
+@pytest.fixture
+def account():
+    def _account(enabled, bills_oustanding=None):
+        if bills_oustanding is None:
+            bills_oustanding = []
+        data = {"feature": {"enabled": enabled}, "bills_outstanding": bills_oustanding}
+        return SimpleNamespace(**data)
+
+    return _account
+
+
+@pytest.mark.parametrize("enabled_state", (True, False))
+def test_initilaize_state_machine(account, enabled_state):
+    my_account = account(enabled=True)
+    t = EnableFeatureStateMachine(my_account)
+    assert t.state is True
+
+
+def test_disable_enabled_account(account):
+    enabled_account = account(enabled=True)
+    t = EnableFeatureStateMachine(enabled_account)
+
+    t.disable_feature()
+    assert t.state is False
+
+
+def test_reenable_enabled_account(account):
+    enabled_account = account(enabled=True)
+    t = EnableFeatureStateMachine(enabled_account)
+
+    t.enable_feature()
+    assert t.state is True

--- a/tests/examples/test_boolean_field.py
+++ b/tests/examples/test_boolean_field.py
@@ -1,7 +1,4 @@
-try:
-    from types import SimpleNamespace
-except ImportError:
-    from argparse import Namespace as SimpleNamespace
+from types import SimpleNamespace
 
 import pytest
 

--- a/tests/examples/test_boolean_field.py
+++ b/tests/examples/test_boolean_field.py
@@ -1,4 +1,7 @@
-from types import SimpleNamespace
+try:
+    from types import SimpleNamespace
+except ImportError:
+    from argparse import Namespace as SimpleNamespace
 
 import pytest
 

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,4 +1,4 @@
-from finite_state_machine import StateMachine
+from finite_state_machine import StateMachine, transition
 import pytest
 
 
@@ -12,3 +12,27 @@ def test_state_machine():
 
     with pytest.raises(ValueError):
         LightSwitch()
+
+
+def test_source_parameter_is_tuple():
+    with pytest.raises(ValueError):
+
+        @transition(source=("here",), target="there")
+        def conditions_check(instance):
+            pass
+
+
+def test_target_parameter_is_tuple():
+    with pytest.raises(ValueError):
+
+        @transition(source="here", target=("there",))
+        def conditions_check(instance):
+            pass
+
+
+def test_conditions_parameter_is_tuple():
+    with pytest.raises(ValueError):
+
+        @transition(source="here", target="there", conditions=(1, 2))
+        def conditions_check(instance):
+            pass


### PR DESCRIPTION
Adding additional types will make it easier to use this library in conjunction with ORMs where Booleans and Enums are used to manage state.

PR includes an example workflow of how to set up a boolean state machine.