### PR TITLE
Generate state machine diagram in Mermaid Markdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ test-cov: ## run tests with coverage
 
 test-covhtml: ## run tests with coverage; view in browser
 	pytest --cov finite_state_machine/ --cov examples/ --cov-report html && open ./htmlcov/index.html
+
+changelog:  ## generate changelog v=""
+	python ./scripts/generate_changelog.py --version=$(v)

--- a/README.md
+++ b/README.md
@@ -135,16 +135,16 @@ State Machine workflows can be visualized using a
 which can be viewed using the
 [Mermaid Live Editor](https://mermaid-js.github.io/mermaid-live-editor).
 
-Use the `draw_state_diagram` command and point to
+Use the `fsm_draw_state_diagram` command and point to
 State Machine workflow class
 that inheritences from `StateMachine`.
 
 ```console
 # class parameter is required
-$ draw_state_diagram --class examples.turnstile:Turnstile
+$ fsm_draw_state_diagram --class examples.turnstile:Turnstile
 
 # initial_state parameter is optional
-$ draw_state_diagram --class examples.turnstile:Turnstile --initial_state close
+$ fsm_draw_state_diagram --class examples.turnstile:Turnstile --initial_state close
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@
 
 Lightweight, decorator-based Python implementation of a [Finite State Machine](https://en.wikipedia.org/wiki/Finite-state_machine).
 
+#### Table of Contents
+
+<!-- TOC -->
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Example](#example)
+- [State Diagram](#state-diagram)
+- [Contributing](#contributing)
+- [Inspiration](#inspiration)
+
+<!-- /TOC -->
+
 ## Installation
 
 ```console
@@ -110,7 +123,29 @@ InvalidStartState                         Traceback (most recent call last)
 InvalidStartState:
 ```
 
-The [examples](/examples) folder has additional State Machine workflows.
+The [examples](/examples) folder contains additional workflows.
+
+## State Diagram
+
+State Machine workflows can be visualized using a
+[state diagram](https://en.wikipedia.org/wiki/State_diagram).
+
+`finite-state-machine` generates diagrams using
+[Mermaid Markdown syntax](https://mermaid-js.github.io),
+which can be viewed using the
+[Mermaid Live Editor](https://mermaid-js.github.io/mermaid-live-editor).
+
+Use the `draw_state_diagram` command and point to
+State Machine workflow class
+that inheritences from `StateMachine`.
+
+```console
+# class parameter is required
+$ draw_state_diagram --class examples.turnstile:Turnstile
+
+# initial_state parameter is optional
+$ draw_state_diagram --class examples.turnstile:Turnstile --initial_state close
+```
 
 ## Contributing
 
@@ -126,25 +161,8 @@ The [examples](/examples) folder has additional State Machine workflows.
 pytest
 ```
 
-## Release
-
-Use SemVer for versioning strategy
-
-### Instructions
-
-1. Grab last version, `X.Y.Z`
-1. Generate changelog: `python scripts/generate_changelog.py -v X.Y.Z`
-1. Cut a release on GitHub
-1. Upload to PyPI with [flit](https://github.com/takluyver/flit)
-
-### Flit Workflow
-
-```console
-pip install flit
-flit build --format sdist
-flit publish --repository testpypi
-```
-
 ## Inspiration
 
-This project is inspired by [django-fsm](https://github.com/viewflow/django-fsm/). Wanted a decorator-based state machine without having to use Django.
+This project is inspired by
+[django-fsm](https://github.com/viewflow/django-fsm/).
+I wanted a decorator-based state machine without having to use Django.

--- a/finite_state_machine/__init__.py
+++ b/finite_state_machine/__init__.py
@@ -3,5 +3,4 @@
 __version__ = "0.2.0"
 
 
-from .draw_state_diagram import create_state_diagram_in_mermaid_markdown  # noqa
 from .state_machine import StateMachine, transition  # noqa

--- a/finite_state_machine/__init__.py
+++ b/finite_state_machine/__init__.py
@@ -3,4 +3,5 @@
 __version__ = "0.2.0"
 
 
+from .draw_state_diagram import create_state_diagram_in_mermaid_markdown  # noqa
 from .state_machine import StateMachine, transition  # noqa

--- a/finite_state_machine/draw_state_diagram.py
+++ b/finite_state_machine/draw_state_diagram.py
@@ -8,10 +8,6 @@ from typing import List
 from finite_state_machine.state_machine import Transition
 
 
-def add_current_working_directory_to_path():
-    sys.path.append(os.getcwd())
-
-
 def import_state_machine_class(class_path):
     modname, qualname_separator, qualname = class_path.partition(":")
     obj = importlib.import_module(modname)
@@ -21,7 +17,7 @@ def import_state_machine_class(class_path):
     return obj
 
 
-def create_state_diagram_in_mermaid_markdown(cls):
+def create_state_diagram_in_mermaid_markdown(cls, initial_state):
     """Create State Diagram in Mermaid Markdown
 
     https://mermaid-js.github.io/mermaid/diagrams-and-syntax-and-examples/stateDiagram.html
@@ -67,7 +63,8 @@ def create_state_diagram_in_mermaid_markdown(cls):
                 all_state_transitions.append(t)
 
         mermaid_markdown = "stateDiagram-v2\n"
-        mermaid_markdown += f"    [*] --> {cls.initial_state}\n"
+        if initial_state:
+            mermaid_markdown += f"    [*] --> {initial_state}\n"
         for t in all_state_transitions:
             mermaid_markdown += t
 
@@ -84,15 +81,24 @@ def parse_args():
         help="Path to State Machine class, e.g. importable.module:class",
         required=True,
     )
+    parser.add_argument(
+        "--initial_state",
+        type=str,
+        help="Initial state of State Machine",
+        required=False,
+    )
     return vars(parser.parse_args())
 
 
 def main():
     args = parse_args()
     class_path = args["class"]
-    add_current_working_directory_to_path()
+    initial_state = args["initial_state"]
+
+    sys.path.append(os.getcwd())
     class_obj = import_state_machine_class(class_path)
-    markdown = create_state_diagram_in_mermaid_markdown(class_obj)
+
+    markdown = create_state_diagram_in_mermaid_markdown(class_obj, initial_state)
     print(markdown)
 
 

--- a/finite_state_machine/draw_state_diagram.py
+++ b/finite_state_machine/draw_state_diagram.py
@@ -1,7 +1,18 @@
+import argparse
+import importlib
 import inspect
 from typing import List
 
-from .state_machine import Transition
+from finite_state_machine.state_machine import Transition
+
+
+def import_state_machine_class(class_path):
+    modname, qualname_separator, qualname = class_path.partition(":")
+    obj = importlib.import_module(modname)
+    if qualname_separator:
+        for attr in qualname.split("."):
+            obj = getattr(obj, attr)
+    return obj
 
 
 def create_state_diagram_in_mermaid_markdown(cls):
@@ -50,3 +61,29 @@ def create_state_diagram_in_mermaid_markdown(cls):
             mermaid_markdown += t
 
     return mermaid_markdown
+
+
+def parse_args():
+    # TODO make this callable from the command line where you can pass in information
+    description = "Create State Diagram for a State Machine"
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "-c",
+        "--class",
+        type=str,
+        help="Path to State Machine class, e.g. importable.module:class",
+        required=True,
+    )
+    return vars(parser.parse_args())
+
+
+def main():
+    args = parse_args()
+    class_path = args["class"]
+    class_obj = import_state_machine_class(class_path)
+    markdown = create_state_diagram_in_mermaid_markdown(class_obj)
+    print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/finite_state_machine/draw_state_diagram.py
+++ b/finite_state_machine/draw_state_diagram.py
@@ -1,0 +1,52 @@
+import inspect
+from typing import List
+
+from .state_machine import Transition
+
+
+def create_state_diagram_in_mermaid_markdown(cls):
+    class_fns = inspect.getmembers(cls, predicate=inspect.isfunction)
+    state_transitions: List[Transition] = [
+        func.__fsm for name, func in class_fns if hasattr(func, "__fsm")
+    ]
+
+    transition_template = "    {source} --> {target} : {name}\n"
+
+    all_state_transitions = []
+    for state_transition in state_transitions:
+        if isinstance(state_transition.source, list):
+            for src in state_transition.source:
+                t = transition_template.format(
+                    source=src,
+                    target=state_transition.target,
+                    name=state_transition.name,
+                )
+                all_state_transitions.append(t)
+
+                if state_transition.on_error:
+                    t = transition_template.format(
+                        source=src, target=state_transition.on_error, name="on_error"
+                    )
+                    all_state_transitions.append(t)
+        else:
+            t = transition_template.format(
+                source=state_transition.source,
+                target=state_transition.target,
+                name=state_transition.name,
+            )
+            all_state_transitions.append(t)
+
+            if state_transition.on_error:
+                t = transition_template.format(
+                    source=state_transition.source,
+                    target=state_transition.on_error,
+                    name="on_error",
+                )
+                all_state_transitions.append(t)
+
+        mermaid_markdown = "stateDiagram-v2\n"
+        mermaid_markdown += f"    [*] --> {cls.initial_state}\n"
+        for t in all_state_transitions:
+            mermaid_markdown += t
+
+    return mermaid_markdown

--- a/finite_state_machine/draw_state_diagram.py
+++ b/finite_state_machine/draw_state_diagram.py
@@ -17,7 +17,7 @@ def import_state_machine_class(class_path):
     return obj
 
 
-def create_state_diagram_in_mermaid_markdown(cls, initial_state):
+def generate_state_diagram_markdown(cls, initial_state):
     """Create State Diagram in Mermaid Markdown
 
     https://mermaid-js.github.io/mermaid/diagrams-and-syntax-and-examples/stateDiagram.html
@@ -97,7 +97,7 @@ def main():
     sys.path.append(os.getcwd())
     class_obj = import_state_machine_class(class_path)
 
-    markdown = create_state_diagram_in_mermaid_markdown(class_obj, initial_state)
+    markdown = generate_state_diagram_markdown(class_obj, initial_state)
     print(markdown)
 
 

--- a/finite_state_machine/draw_state_diagram.py
+++ b/finite_state_machine/draw_state_diagram.py
@@ -8,8 +8,12 @@ from typing import List
 from finite_state_machine.state_machine import Transition
 
 
-def import_state_machine_class(class_path):
-    modname, qualname_separator, qualname = class_path.partition(":")
+def import_state_machine_class(path):  # pragma: no cover
+    """Load State Machine workflow class
+
+    Copied from https://packaging.python.org/specifications/entry-points/#data-model
+    """
+    modname, qualname_separator, qualname = path.partition(":")
     obj = importlib.import_module(modname)
     if qualname_separator:
         for attr in qualname.split("."):
@@ -71,7 +75,7 @@ def generate_state_diagram_markdown(cls, initial_state):
     return mermaid_markdown
 
 
-def parse_args():
+def parse_args():  # pragma: no cover
     description = "Create State Diagram for a State Machine"
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
@@ -89,7 +93,7 @@ def parse_args():
     return vars(parser.parse_args())
 
 
-def main():
+def main():  # pragma: no cover
     args = parse_args()
     class_path = args["class"]
     initial_state = args["initial_state"]

--- a/finite_state_machine/draw_state_diagram.py
+++ b/finite_state_machine/draw_state_diagram.py
@@ -75,7 +75,6 @@ def parse_args():
     description = "Create State Diagram for a State Machine"
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
-        "-c",
         "--class",
         type=str,
         help="Path to State Machine class, e.g. importable.module:class",

--- a/finite_state_machine/draw_state_diagram.py
+++ b/finite_state_machine/draw_state_diagram.py
@@ -1,9 +1,15 @@
 import argparse
 import importlib
 import inspect
+import os
+import sys
 from typing import List
 
 from finite_state_machine.state_machine import Transition
+
+
+def add_current_working_directory_to_path():
+    sys.path.append(os.getcwd())
 
 
 def import_state_machine_class(class_path):
@@ -16,6 +22,11 @@ def import_state_machine_class(class_path):
 
 
 def create_state_diagram_in_mermaid_markdown(cls):
+    """Create State Diagram in Mermaid Markdown
+
+    https://mermaid-js.github.io/mermaid/diagrams-and-syntax-and-examples/stateDiagram.html
+    """
+
     class_fns = inspect.getmembers(cls, predicate=inspect.isfunction)
     state_transitions: List[Transition] = [
         func.__fsm for name, func in class_fns if hasattr(func, "__fsm")
@@ -64,7 +75,6 @@ def create_state_diagram_in_mermaid_markdown(cls):
 
 
 def parse_args():
-    # TODO make this callable from the command line where you can pass in information
     description = "Create State Diagram for a State Machine"
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
@@ -80,6 +90,7 @@ def parse_args():
 def main():
     args = parse_args()
     class_path = args["class"]
+    add_current_working_directory_to_path()
     class_obj = import_state_machine_class(class_path)
     markdown = create_state_diagram_in_mermaid_markdown(class_obj)
     print(markdown)

--- a/finite_state_machine/state_machine.py
+++ b/finite_state_machine/state_machine.py
@@ -1,4 +1,6 @@
 import functools
+from typing import NamedTuple, Union
+
 from .exceptions import ConditionNotMet, InvalidStartState
 
 
@@ -8,6 +10,14 @@ class StateMachine:
             self.state
         except AttributeError:
             raise ValueError("Need to set a state instance variable")
+
+
+class Transition(NamedTuple):
+    name: str
+    source: Union[list, bool, int, str]
+    target: Union[bool, int, str]
+    conditions: list
+    on_error: Union[bool, int, str]
 
 
 def transition(source, target, conditions=None, on_error=None):
@@ -31,6 +41,8 @@ def transition(source, target, conditions=None, on_error=None):
             raise ValueError("on_error needs to be a bool, int or string")
 
     def transition_decorator(func):
+        func.__fsm = Transition(func.__name__, source, target, conditions, on_error)
+
         @functools.wraps(func)
         def _wrapper(*args, **kwargs):
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,4 @@ license="MIT"
 exclude = ["tests"]
 
 [tool.flit.scripts]
-draw_state_diagram = "finite_state_machine.draw_state_diagram:main"
+fsm_draw_state_diagram = "finite_state_machine.draw_state_diagram:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,6 @@ license="MIT"
 
 [tool.flit.sdist]
 exclude = ["tests"]
+
+[tool.flit.scripts]
+draw_state_diagram = "finite_state_machine.draw_state_diagram:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# this library does not have any external dependencies

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,4 @@
-pytest
-pytest-cov
+-r requirements.txt
+pytest==6.0.1
+pytest-cov==2.10.1
+requests==2.23.0

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,7 @@
+# Scripts
+
+This folder contains tools to manage this repository.
+
+## `generate_changelog.py`
+
+Used to generate a CHANGELOG for release.

--- a/tests/test_draw_state_diagram.py
+++ b/tests/test_draw_state_diagram.py
@@ -1,0 +1,30 @@
+from finite_state_machine import (
+    create_state_diagram_in_mermaid_markdown,
+    StateMachine,
+    transition,
+)
+
+
+def test_turnstile_diagram():
+    # Arrange
+    class Turnstile(StateMachine):
+        initial_state = "close"
+
+        @transition(source=["close", "open"], target="open")
+        def insert_coin(self):
+            pass
+
+        @transition(source="open", target="close", on_error="failed")
+        def pass_thru(self):
+            pass
+
+    # Act
+    mermaid_markdown = create_state_diagram_in_mermaid_markdown(Turnstile)
+
+    # Assert
+    assert "stateDiagram-v2" in mermaid_markdown
+    assert "[*] --> close" in mermaid_markdown
+    assert "close --> open : insert_coin" in mermaid_markdown
+    assert "open --> open : insert_coin" in mermaid_markdown
+    assert "open --> close : pass_thru" in mermaid_markdown
+    assert "open --> failed : on_error" in mermaid_markdown

--- a/tests/test_draw_state_diagram.py
+++ b/tests/test_draw_state_diagram.py
@@ -20,6 +20,7 @@ def test_turnstile_diagram_without_initial_state():
 
     # Assert
     assert "stateDiagram-v2" in mermaid_markdown
+    assert "[*] --> close" not in mermaid_markdown
     assert "close --> open : insert_coin" in mermaid_markdown
     assert "open --> open : insert_coin" in mermaid_markdown
     assert "open --> close : pass_thru" in mermaid_markdown

--- a/tests/test_draw_state_diagram.py
+++ b/tests/test_draw_state_diagram.py
@@ -1,8 +1,5 @@
-from finite_state_machine import (
-    create_state_diagram_in_mermaid_markdown,
-    StateMachine,
-    transition,
-)
+from finite_state_machine import StateMachine, transition
+from finite_state_machine.draw_state_diagram import generate_state_diagram_markdown
 
 
 def test_turnstile_diagram_without_initial_state():
@@ -19,9 +16,7 @@ def test_turnstile_diagram_without_initial_state():
             pass
 
     # Act
-    mermaid_markdown = create_state_diagram_in_mermaid_markdown(
-        Turnstile, initial_state=None
-    )
+    mermaid_markdown = generate_state_diagram_markdown(Turnstile, initial_state=None)
 
     # Assert
     assert "stateDiagram-v2" in mermaid_markdown
@@ -45,9 +40,7 @@ def test_turnstile_diagram_with_initial_state():
             pass
 
     # Act
-    mermaid_markdown = create_state_diagram_in_mermaid_markdown(
-        Turnstile, initial_state="close"
-    )
+    mermaid_markdown = generate_state_diagram_markdown(Turnstile, initial_state="close")
 
     # Assert
     assert "stateDiagram-v2" in mermaid_markdown

--- a/tests/test_draw_state_diagram.py
+++ b/tests/test_draw_state_diagram.py
@@ -5,7 +5,7 @@ from finite_state_machine import (
 )
 
 
-def test_turnstile_diagram():
+def test_turnstile_diagram_without_initial_state():
     # Arrange
     class Turnstile(StateMachine):
         initial_state = "close"
@@ -19,7 +19,35 @@ def test_turnstile_diagram():
             pass
 
     # Act
-    mermaid_markdown = create_state_diagram_in_mermaid_markdown(Turnstile)
+    mermaid_markdown = create_state_diagram_in_mermaid_markdown(
+        Turnstile, initial_state=None
+    )
+
+    # Assert
+    assert "stateDiagram-v2" in mermaid_markdown
+    assert "close --> open : insert_coin" in mermaid_markdown
+    assert "open --> open : insert_coin" in mermaid_markdown
+    assert "open --> close : pass_thru" in mermaid_markdown
+    assert "open --> failed : on_error" in mermaid_markdown
+
+
+def test_turnstile_diagram_with_initial_state():
+    # Arrange
+    class Turnstile(StateMachine):
+        initial_state = "close"
+
+        @transition(source=["close", "open"], target="open")
+        def insert_coin(self):
+            pass
+
+        @transition(source="open", target="close", on_error="failed")
+        def pass_thru(self):
+            pass
+
+    # Act
+    mermaid_markdown = create_state_diagram_in_mermaid_markdown(
+        Turnstile, initial_state="close"
+    )
 
     # Assert
     assert "stateDiagram-v2" in mermaid_markdown


### PR DESCRIPTION
Closes #4 

Added a `fsm_draw_state_machine` command line script that takes in a workflow that inherits from `StateMachine` and generates a state diagram.