### PR TITLE
Only support Python 3.6+

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Finite State Machine
 
-[![Python 3.6+](https://img.shields.io/badge/Python-3.6+-blue.svg)](https://www.python.org/download/releases/3.6.0/)
 [![Build Status](https://github.com/alysivji/finite-state-machine/workflows/build/badge.svg)](https://github.com/alysivji/finite-state-machine/actions?query=workflow%3A%22build%22)
+[![Latest Release](https://img.shields.io/pypi/v/finite-state-machine)](https://pypi.org/project/finite-state-machine/)
+[![Supports Python 3.6+](https://img.shields.io/badge/Python-3.6+-blue.svg)](https://www.python.org/download/releases/3.6.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-red.svg)](https://opensource.org/licenses/MIT)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Finite State Machine
 
+[![Python 3.6+](https://img.shields.io/badge/Python-3.6+-blue.svg)](https://www.python.org/download/releases/3.6.0/)
 [![Build Status](https://github.com/alysivji/finite-state-machine/workflows/build/badge.svg)](https://github.com/alysivji/finite-state-machine/actions?query=workflow%3A%22build%22)
 [![License: MIT](https://img.shields.io/badge/License-MIT-red.svg)](https://opensource.org/licenses/MIT)
 [![Code Style: Black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/ambv/black)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,9 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.5",
-    "Programming Language :: Python :: 3.4",
-    "Programming Language :: Python :: 3.3",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-requires-python = "!=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, >=3.3, <4"
+requires-python = ">=3.6, <4"
 keywords="finite-state-machine finite-automata state-machine"
 license="MIT"
 


### PR DESCRIPTION
Closes #8 

This library supported Python 2.7+ as the code was the same and did not require maintenance work. Now that we are adding additional features, it makes sense to restrict to only support active Python releases.

[Python 3.5.10 was released on September 5th, 2020](https://www.python.org/dev/peps/pep-0478/) and there are no plans for additional releases. This library is following suit and only supporting Python 3.6. 

This PR also adds badges to the README.me