### PR TITLE
Handle transition function edge case when on_error is not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ help: ## help
 install: ## install development requirements
 	pip install -r requirements_dev.txt
 
+install-localdev:  ## install library for local development; pip install -e .
+	flit install --symlink
+
 test: ## run tests
 	pytest
 

--- a/finite_state_machine/state_machine.py
+++ b/finite_state_machine/state_machine.py
@@ -57,12 +57,21 @@ def transition(source, target, conditions=None, on_error=None):
                 if not condition(self):
                     raise ConditionNotMet(condition)
 
+            if not on_error:
+                result = func(*args, **kwargs)
+                self.state = target
+                return result
+
             try:
                 result = func(*args, **kwargs)
                 self.state = target
                 return result
             except Exception:
+                # TODO should we log this somewhere?
+                # logger.error? maybe have an optional parameter to set this up
+                # how to libraries log?
                 self.state = on_error
+                return
 
         return _wrapper
 

--- a/finite_state_machine/state_machine.py
+++ b/finite_state_machine/state_machine.py
@@ -51,7 +51,11 @@ def transition(source, target, conditions=None, on_error=None):
                 self = args[0]
 
             if self.state not in source:
-                raise InvalidStartState
+                exception_message = (
+                    f"Current state is {self.state}. "
+                    f"{func.__name__} allows transitions from {source}."
+                )
+                raise InvalidStartState(exception_message)
 
             for condition in conditions:
                 if not condition(self):

--- a/tests/examples/test_boolean_field.py
+++ b/tests/examples/test_boolean_field.py
@@ -52,5 +52,5 @@ def test_enabled_account_cannot_be_reenabled(create_account):
     account = create_account(enabled=True)
     t = EnableFeatureStateMachine(account)
 
-    with pytest.raises(InvalidStartState):
+    with pytest.raises(InvalidStartState, match="Current state is True"):
         t.enable_feature()

--- a/tests/examples/test_turnstile.py
+++ b/tests/examples/test_turnstile.py
@@ -22,5 +22,5 @@ def test_turnstile__cannot_pass_thru_closed_turnstile():
     t = Turnstile()
     assert t.state == "close"
 
-    with pytest.raises(InvalidStartState):
+    with pytest.raises(InvalidStartState, match="Current state is close"):
         t.pass_thru()

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -68,3 +68,26 @@ class TestExceptionStateHandling:
 
         # Assert
         assert switch.state == "failed"
+
+    def test_on_error_parameter_is_not_set_and_transition_function_raises_error(self):
+        """Transition function raises error, but on_error parameter is not set"""
+
+        class LightSwitch(StateMachine):
+            def __init__(self):
+                self.state = "off"
+
+            @transition(source="off", target="on")
+            def turn_on(self):
+                raise ValueError("expected error")
+
+            @transition(source="on", target="off")
+            def turn_off(self):
+                pass
+
+        # Arrange
+        switch = LightSwitch()
+        assert switch.state == "off"
+
+        # Act
+        with pytest.raises(ValueError, match="expected error"):
+            switch.turn_on()

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -47,6 +47,8 @@ class TestExceptionStateHandling:
                 pass
 
     def test_state_machine_goes_into_on_error_state_when_exception_occurs(self):
+        """happy path"""
+
         class LightSwitch(StateMachine):
             def __init__(self):
                 self.state = "off"
@@ -88,6 +90,6 @@ class TestExceptionStateHandling:
         switch = LightSwitch()
         assert switch.state == "off"
 
-        # Act
+        # Act / Assert
         with pytest.raises(ValueError, match="expected error"):
             switch.turn_on()

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -47,7 +47,7 @@ class TestExceptionStateHandling:
                 pass
 
     def test_state_machine_goes_into_on_error_state_when_exception_occurs(self):
-        """happy path"""
+        """happy path when error occurs"""
 
         class LightSwitch(StateMachine):
             def __init__(self):
@@ -70,6 +70,31 @@ class TestExceptionStateHandling:
 
         # Assert
         assert switch.state == "failed"
+
+    def test_state_machine_transition_function_does_not_raise_exception(self):
+        """happy path => when transition function runs without an error"""
+
+        class LightSwitch(StateMachine):
+            def __init__(self):
+                self.state = "off"
+
+            @transition(source="off", target="on", on_error="failed")
+            def turn_on(self):
+                pass
+
+            @transition(source="on", target="off", on_error="failed")
+            def turn_off(self):
+                pass
+
+        # Arrange
+        switch = LightSwitch()
+        assert switch.state == "off"
+
+        # Act
+        switch.turn_on()
+
+        # Assert
+        assert switch.state == "on"
 
     def test_on_error_parameter_is_not_set_and_transition_function_raises_error(self):
         """Transition function raises error, but on_error parameter is not set"""


### PR DESCRIPTION
If users do not specify an `on_error` parameter, we want the exception to bubble up and not be suppressed.

Also improved error messages for when the start state is invalid.