### PR TITLE
Objects inheriting from allowed_types can be used as states

### DIFF
--- a/finite_state_machine/state_machine.py
+++ b/finite_state_machine/state_machine.py
@@ -22,14 +22,14 @@ class Transition(NamedTuple):
 
 
 def transition(source, target, conditions=None, on_error=None):
-    allowed_types = [str, bool, int]
+    allowed_types = (str, bool, int)
 
-    if type(source) in allowed_types:
+    if isinstance(source, allowed_types):
         source = [source]
     if not isinstance(source, list):
         raise ValueError("Source can be a bool, int, string or list")
 
-    if type(target) not in allowed_types:
+    if not isinstance(target, allowed_types):
         raise ValueError("Target needs to be a bool, int or string")
 
     if not conditions:
@@ -41,7 +41,7 @@ def transition(source, target, conditions=None, on_error=None):
             raise ValueError("conditions list must contain functions")
 
     if on_error:
-        if type(on_error) not in allowed_types:
+        if not isinstance(on_error, allowed_types):
             raise ValueError("on_error needs to be a bool, int or string")
 
     def transition_decorator(func):

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,3 +1,5 @@
+from enum import IntEnum
+
 from finite_state_machine import StateMachine, transition
 from finite_state_machine.exceptions import ConditionsNotMet
 import pytest
@@ -21,6 +23,16 @@ def test_source_parameter_is_tuple():
         @transition(source=("here",), target="there")
         def conditions_check(instance):
             pass
+
+
+def test_source_target_parameters_are_int_like():
+    class States(IntEnum):
+        some_state = 0
+        some_other_state = 1
+
+    @transition(source=States.some_state, target=States.some_other_state)
+    def conditions_check(instance):
+        pass
 
 
 def test_target_parameter_is_tuple():


### PR DESCRIPTION
This PR allows objects inheriting from `allowed_types` to be used as states. Especially, this change allows to use `enum.IntEnum` instances as states.